### PR TITLE
Make colors configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,10 @@ pub fn config() -> &'static Config {
     CONFIG.get().expect("config not initialized")
 }
 
+pub fn colors() -> &'static Colors {
+    &config().colors
+}
+
 /// Platform-agnostic key representation.
 /// Each backend maps its native keycodes to these values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -258,11 +262,109 @@ impl KeyBindings {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
+///Colors stored as BGRA
+pub struct Colors {
+    #[serde(with = "from_hex")]
+    pub cell_normal: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub cell_drag: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub cell_highlight: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_first: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_second: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_highlight: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_dim: [u8; 4],
+
+    // // Sub-grid
+    #[serde(with = "from_hex")]
+    pub sub_cell_normal: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub sub_bg: [u8; 4],
+    // // Macro UI
+    #[serde(with = "from_hex")]
+    pub panel_bg: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_white: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub text_grey: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub selected_bg: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub rec_bg: [u8; 4],
+
+    #[serde(with = "from_hex")]
+    pub border: [u8; 4],
+    #[serde(with = "from_hex")]
+    pub border_dragging: [u8; 4],
+}
+mod from_hex {
+    use serde::{Deserialize, Deserializer, Serializer};
+    pub fn serialize<S: Serializer>(color: &[u8; 4], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!(
+            "#{:02X}{:02X}{:02X}{:02X}",
+            color[2], color[1], color[0], color[3]
+        ))
+    }
+    ///Deserialize from #RRGGBBAA  to [BB,GG,RR,AA]
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 4], D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let hex = s.trim_start_matches("#");
+        let rgba = match hex.len() {
+            6 => u32::from_str_radix(&hex, 16)
+                .map(|a| a << 8)
+                .unwrap_or_default(),
+            8 => u32::from_str_radix(&hex, 16).unwrap_or_default(),
+            _ => 0,
+        };
+        Ok([
+            ((rgba & 0x0000FF00) >> 8) as u8,
+            ((rgba & 0x00FF0000) >> 16) as u8,
+            ((rgba & 0xFF000000) >> 24) as u8,
+            (rgba & 0x000000FF) as u8,
+        ])
+    }
+}
+
+impl Default for Colors {
+    fn default() -> Self {
+        Self {
+            //store in BGRA
+            cell_normal: [0x00, 0x00, 0x00, 0x66], //overlay transparency
+            cell_drag: [0x40, 0x00, 0x40, 0x88],   //dark purple
+            cell_highlight: [0x14, 0x30, 0x14, 0xAA], //dark green
+            text_first: [0x00, 0xDC, 0xFF, 0xFF],  //yellow
+            text_second: [0xFF, 0xBE, 0x50, 0xFF], //sky blue
+            text_highlight: [0x50, 0xFF, 0x50, 0xFF], //bright lime
+            text_dim: [0x66, 0x66, 0x66, 0xAA],
+
+            // // Sub-grid
+            sub_cell_normal: [0x30, 0x10, 0x00, 0xAA], //dark navy
+            sub_bg: [0x30, 0x10, 0x00, 0x99],
+
+            // // Macro UI
+            panel_bg: [0x18, 0x0C, 0x00, 0xEE], //very dark warm
+            text_white: [0xFF, 0xFF, 0xFF, 0xFF],
+            text_grey: [0x88, 0x88, 0x88, 0xFF],
+            selected_bg: [0x30, 0x50, 0x20, 0xFF], //dark green
+            rec_bg: [0x00, 0x00, 0xCC, 0xFF],
+            border: [0x00, 0xA5, 0xFF, 0xFF],          //amber
+            border_dragging: [0xFF, 0x00, 0xFF, 0xFF], //magenta
+        }
+    }
+}
+
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub grid: GridConfig,
     pub keys: KeyBindings,
+    pub colors: Colors,
 }
 
 impl Config {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,26 +1,8 @@
-use crate::input::{cols, hints, rows, sub_cols, sub_hints, sub_rows, InputState};
+use crate::{
+    config::colors,
+    input::{cols, hints, rows, sub_cols, sub_hints, sub_rows, InputState},
+};
 use font8x8::UnicodeFonts;
-
-// ARGB8888 — byte order on disk/in memory is [Blue, Green, Red, Alpha]
-
-// Main grid
-const CELL_NORMAL: [u8; 4] = [0x00, 0x00, 0x00, 0x66];
-const CELL_DRAG: [u8; 4] = [0x40, 0x00, 0x40, 0x88]; // dark purple
-const CELL_HIGHLIGHT: [u8; 4] = [0x14, 0x30, 0x14, 0xAA]; // dark green
-const TEXT_FIRST: [u8; 4] = [0x00, 0xDC, 0xFF, 0xFF]; // yellow  (RGB 255,220,0)
-const TEXT_SECOND: [u8; 4] = [0xFF, 0xBE, 0x50, 0xFF]; // sky-blue (RGB 80,190,255)
-const TEXT_HIGHLIGHT: [u8; 4] = [0x50, 0xFF, 0x50, 0xFF]; // bright lime
-const TEXT_DIM: [u8; 4] = [0x66, 0x66, 0x66, 0xAA];
-
-// Sub-grid
-const SUB_CELL_NORMAL: [u8; 4] = [0x30, 0x10, 0x00, 0xAA]; // dark navy
-
-// Macro UI
-const PANEL_BG: [u8; 4] = [0x18, 0x0C, 0x00, 0xEE]; // very dark, warm
-const TEXT_WHITE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
-const TEXT_GREY: [u8; 4] = [0x88, 0x88, 0x88, 0xFF];
-const SELECTED_BG: [u8; 4] = [0x30, 0x50, 0x20, 0xFF]; // dark green
-const REC_BG: [u8; 4] = [0x00, 0x00, 0xCC, 0xFF]; // red
 
 const FONT_SCALE: u32 = 2;
 const LINE_H: u32 = 24;
@@ -54,7 +36,11 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
     let char_h = 8 * FONT_SCALE;
     let gap = 3u32;
     let label_w = char_w * 2 + gap;
-    let cell_normal = if dragging { CELL_DRAG } else { CELL_NORMAL };
+    let cell_normal = if dragging {
+        colors().cell_drag
+    } else {
+        colors().cell_normal
+    };
 
     for row in 0..nrows {
         for col in 0..ncols {
@@ -64,12 +50,16 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
             let second_hint = hints[row as usize];
 
             let (cell_bg, c1, c2) = match input {
-                InputState::First => (Some(cell_normal), TEXT_FIRST, TEXT_SECOND),
+                InputState::First => (Some(cell_normal), colors().text_first, colors().text_second),
                 InputState::Second(typed) => {
                     if first_hint == *typed {
-                        (Some(CELL_HIGHLIGHT), TEXT_HIGHLIGHT, TEXT_SECOND)
+                        (
+                            Some(colors().cell_highlight),
+                            colors().text_highlight,
+                            colors().text_second,
+                        )
                     } else {
-                        (None, TEXT_DIM, TEXT_DIM)
+                        (None, colors().text_dim, colors().text_dim)
                     }
                 }
                 _ => unreachable!(),
@@ -89,37 +79,37 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
 
 pub fn render_rec_indicator(buf: &mut [u8], w: u32) {
     let mut c = Canvas { buf, w };
-    c.fill_rect(8, 8, 56, 24, REC_BG);
-    c.draw_text(12, 12, b"REC", TEXT_WHITE, 2);
+    c.fill_rect(8, 8, 56, 24, colors().rec_bg);
+    c.draw_text(12, 12, b"REC", colors().text_white, 2);
 }
 
 pub fn render_macro_bind_key(buf: &mut [u8], w: u32, h: u32) {
     let mut p = Panel::new(buf, w, h, 6);
-    p.text(b"save macro", TEXT_FIRST)
+    p.text(b"save macro", colors().text_first)
         .skip()
-        .text(b"press a key to bind", TEXT_WHITE)
-        .text(b"enter to skip binding", TEXT_GREY)
-        .text(b"escape to cancel", TEXT_GREY);
+        .text(b"press a key to bind", colors().text_white)
+        .text(b"enter to skip binding", colors().text_grey)
+        .text(b"escape to cancel", colors().text_grey);
 }
 
 pub fn render_macro_name(buf: &mut [u8], w: u32, h: u32, name: &[char], bind_key: Option<char>) {
     let mut p = Panel::new(buf, w, h, 7);
-    p.text(b"name this macro", TEXT_FIRST);
+    p.text(b"name this macro", colors().text_first);
     match bind_key {
-        Some(k) => p.text_with_char(b"bound to ", k, TEXT_GREY),
+        Some(k) => p.text_with_char(b"bound to ", k, colors().text_grey),
         None => p.skip(),
     };
-    p.input_line(name, TEXT_WHITE)
+    p.input_line(name, colors().text_white)
         .skip()
-        .text(b"enter to save", TEXT_GREY)
-        .text(b"escape to cancel", TEXT_GREY);
+        .text(b"enter to save", colors().text_grey)
+        .text(b"escape to cancel", colors().text_grey);
 }
 
 pub fn render_macro_replay_wait(buf: &mut [u8], w: u32, h: u32) {
     let mut p = Panel::new(buf, w, h, 4);
-    p.text(b"press macro key", TEXT_FIRST)
+    p.text(b"press macro key", colors().text_first)
         .skip()
-        .text(b"escape to cancel", TEXT_GREY);
+        .text(b"escape to cancel", colors().text_grey);
 }
 
 pub fn render_macro_search(
@@ -133,15 +123,16 @@ pub fn render_macro_search(
     let max_visible = 10usize;
     let visible = results.len().min(max_visible);
     let mut p = Panel::new(buf, w, h, visible as u32 + 5);
-    p.input_line(query, TEXT_WHITE).skip();
+    p.input_line(query, colors().text_white).skip();
     if results.is_empty() {
-        p.text(b"no results", TEXT_GREY);
+        p.text(b"no results", colors().text_grey);
     } else {
         for (i, (bind_key, name)) in results[..visible].iter().enumerate() {
             p.search_entry(*bind_key, name, i == selected);
         }
     }
-    p.skip().text(b"tab:next enter:select esc:back", TEXT_GREY);
+    p.skip()
+        .text(b"tab:next enter:select esc:back", colors().text_grey);
 }
 
 struct Canvas<'a> {
@@ -219,7 +210,7 @@ impl<'a> Panel<'a> {
         let panel_w = (w * 30 / 100).max(400).min(w);
         let panel_x = (w - panel_w) / 2;
         let panel_y = (h - panel_h) / 2;
-        c.fill_rect(panel_x, panel_y, panel_w, panel_h, PANEL_BG);
+        c.fill_rect(panel_x, panel_y, panel_w, panel_h, colors().panel_bg);
         Self {
             c,
             tx: panel_x + 16,
@@ -271,18 +262,26 @@ impl<'a> Panel<'a> {
                 self.ty.saturating_sub(2),
                 self.pw - 8,
                 LINE_H,
-                SELECTED_BG,
+                colors().selected_bg,
             );
         }
-        let text_color = if selected { TEXT_HIGHLIGHT } else { TEXT_WHITE };
+        let text_color = if selected {
+            colors().text_highlight
+        } else {
+            colors().text_white
+        };
         match bind_key {
             Some(k) => {
-                self.c.draw_text(self.tx, self.ty, b"[", TEXT_GREY, 2);
-                self.c.draw_glyph(self.tx + 16, self.ty, k, TEXT_GREY, 2);
                 self.c
-                    .draw_text(self.tx + 2 * 16, self.ty, b"] ", TEXT_GREY, 2);
+                    .draw_text(self.tx, self.ty, b"[", colors().text_grey, 2);
+                self.c
+                    .draw_glyph(self.tx + 16, self.ty, k, colors().text_grey, 2);
+                self.c
+                    .draw_text(self.tx + 2 * 16, self.ty, b"] ", colors().text_grey, 2);
             }
-            None => self.c.draw_text(self.tx, self.ty, b"[ ] ", TEXT_GREY, 2),
+            None => self
+                .c
+                .draw_text(self.tx, self.ty, b"[ ] ", colors().text_grey, 2),
         }
         self.c
             .draw_text(self.tx + 4 * 16, self.ty, name.as_bytes(), text_color, 2);
@@ -307,13 +306,12 @@ fn render_sub_grid(
     let cell_x = main_col * cell_w;
     let cell_y = main_row * cell_h;
 
-    const SUB_BG: [u8; 4] = [0x30, 0x10, 0x00, 0x99];
-    c.fill_rect(cell_x, cell_y, cell_w, cell_h, SUB_BG);
+    c.fill_rect(cell_x, cell_y, cell_w, cell_h, colors().sub_bg);
 
     let border = if dragging {
-        [0xFF, 0x00, 0xFF, 0xFF_u8] // magenta
+        colors().border_dragging
     } else {
-        [0x00, 0xA5, 0xFF, 0xFF_u8] // amber
+        colors().border
     };
     c.fill_rect(cell_x, cell_y, cell_w, 1, border);
     c.fill_rect(cell_x, cell_y + cell_h - 1, cell_w, 1, border);
@@ -332,9 +330,9 @@ fn render_sub_grid(
             let hint = sub_hints[(sub_row * nsub_cols + sub_col) as usize];
             let is_selected = selected == Some((sub_col, sub_row));
             let (bg, text) = if is_selected {
-                (CELL_HIGHLIGHT, TEXT_HIGHLIGHT)
+                (colors().cell_highlight, colors().text_highlight)
             } else {
-                (SUB_CELL_NORMAL, TEXT_FIRST)
+                (colors().sub_cell_normal, colors().text_first)
             };
             c.fill_rect(x + 1, y + 1, sub_cell_w - 2, sub_cell_h - 2, bg);
             c.draw_glyph(x + glyph_ox, y + glyph_oy, hint, text, 1);


### PR DESCRIPTION
Closes #3 
Allow colors to be readable from the config file. All colors are optional, you just change the colors you want to change.
Using the previous color defaults for the rest.

Config file example:
```toml
[colors]
cell_normal=0x00000030 #very light overlay bg
text_dim=0x00000000 #dont show unselected text
sub_cell_normal=0x00103020 # lighter sub cell
sub_bg=0x00103020 #lighter sub bg
text_first=0x4c9f69ff#more muted first 
text_second=0xa6adc8ff#more muted second
cell_highlight=0x1e1e2f30#nice highlight
text_highlight=0xdcffa9ff
```

Some screenshots:
I prefer slightly more transparency for the background, and more muted colors for the text:
<img width="834" height="804" alt="Screenshot from 2026-04-01 19-32-49" src="https://github.com/user-attachments/assets/1b532b24-5898-4e57-8f01-6a9e9af03970" />

And with unselected text completely transparent.
<img width="782" height="607" alt="Screenshot from 2026-04-01 21-15-44" src="https://github.com/user-attachments/assets/ad062e75-3d8d-47c9-b7dc-5dade5b8fb42" />


