### PR TITLE
feat(config): add font_size option for high-DPI displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Config file location: `~/.config/stochos/config.toml` (respects `XDG_CONFIG_HOME
 All fields are optional. Missing fields use defaults.
 
 ```toml
+font_size = 2  # Glyph scale multiplier for the 8x8 bitmap font: 1=8px, 2=16px, 3=24px
+sub_hint_font_size = 2  # Optional override for sub-grid hint glyphs; defaults to font_size when omitted
+panel_font_size = 2  # Optional override for macro/search popup panels; defaults to sub_hint_font_size, then font_size
+
 [grid]
 hints = ["a", "s", "d", "f", "j", "k", "l", ";", "g", "h", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p"]
 sub_hints = ["a", "s", "d", "f", "j", "k", "l", ";", "g", "h", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "z", "x", "c", "v", "b"]
@@ -137,6 +141,13 @@ border = "#00e676ff"             # Material Green (fresh, visible)
 border_dragging = "#e91e63ff"    # Material Pink (strong attention grabber)
 
 ```
+
+### Font
+
+- `font_size` sets the glyph scale multiplier. Stochos uses an `8x8` bitmap font, so each step adds `8px`: `1=8px`, `2=16px`, `3=24px`, and so on. Default is `2`.
+- Increase `font_size` for high-DPI displays such as `3` or `4` on 4K monitors. Valid range: `1-10`.
+- `sub_hint_font_size` sets the glyph scale multiplier for sub-grid hints. If omitted, it inherits `font_size`. It uses the same `8px` steps and `1-10` range, and still clamps down to fit inside each sub-cell.
+- `panel_font_size` sets the glyph scale multiplier for macro and search popup panels. If omitted, it inherits `sub_hint_font_size`, or `font_size` if that is also unset. It uses the same `8px` steps and `1-10` range.
 
 ### Grid
 

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -34,8 +34,7 @@ pub struct X11Backend {
 
 impl X11Backend {
     pub fn new() -> Result<Self> {
-        let (conn, screen_num) =
-            RustConnection::connect(None).context("connect to X11 display")?;
+        let (conn, screen_num) = RustConnection::connect(None).context("connect to X11 display")?;
 
         // Verify XTest extension is available
         conn.xtest_get_version(2, 2)
@@ -122,9 +121,7 @@ impl X11Backend {
             // Sync to ensure the server has processed the unmap before we
             // simulate input — otherwise the overlay may intercept our own
             // fake events.
-            self.conn
-                .sync()
-                .context("sync after teardown")?;
+            self.conn.sync().context("sync after teardown")?;
             self.mapped = false;
         }
         Ok(())
@@ -132,16 +129,7 @@ impl X11Backend {
 
     fn warp_and_sync(&self, x: u32, y: u32) -> Result<()> {
         self.conn
-            .warp_pointer(
-                x11rb::NONE,
-                self.root,
-                0,
-                0,
-                0,
-                0,
-                x as i16,
-                y as i16,
-            )
+            .warp_pointer(x11rb::NONE, self.root, 0, 0, 0, 0, x as i16, y as i16)
             .context("warp pointer")?;
         self.conn.flush().context("flush after warp")?;
         self.conn.sync().context("sync after warp")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use crate::backend::KeyEvent;
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
+const SCALE_RANGE: std::ops::RangeInclusive<u32> = 1..=10;
 
 pub fn init() {
     CONFIG.set(Config::load()).ok();
@@ -16,6 +17,22 @@ pub fn config() -> &'static Config {
 
 pub fn colors() -> &'static Colors {
     &config().colors
+}
+
+pub fn font_size() -> u32 {
+    config().font_size()
+}
+
+pub fn sub_hint_font_size() -> u32 {
+    config().sub_hint_font_size()
+}
+
+pub fn panel_font_size() -> u32 {
+    config().panel_font_size()
+}
+
+fn clamp_scale(scale: u32) -> u32 {
+    scale.clamp(*SCALE_RANGE.start(), *SCALE_RANGE.end())
 }
 
 /// Platform-agnostic key representation.
@@ -362,12 +379,28 @@ impl Default for Colors {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub grid: GridConfig,
     pub keys: KeyBindings,
     pub colors: Colors,
+    pub font_size: u32,
+    pub sub_hint_font_size: Option<u32>,
+    pub panel_font_size: Option<u32>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            grid: GridConfig::default(),
+            keys: KeyBindings::default(),
+            colors: Colors::default(),
+            font_size: 2,
+            sub_hint_font_size: None,
+            panel_font_size: None,
+        }
+    }
 }
 
 impl Config {
@@ -377,6 +410,21 @@ impl Config {
             Ok(data) => toml::from_str(&data).unwrap_or_default(),
             Err(_) => Config::default(),
         }
+    }
+
+    pub fn font_size(&self) -> u32 {
+        clamp_scale(self.font_size)
+    }
+
+    pub fn sub_hint_font_size(&self) -> u32 {
+        self.sub_hint_font_size
+            .map_or_else(|| self.font_size(), clamp_scale)
+    }
+
+    pub fn panel_font_size(&self) -> u32 {
+        self.panel_font_size
+            .or(self.sub_hint_font_size)
+            .map_or_else(|| self.font_size(), clamp_scale)
     }
 
     pub fn cols(&self) -> u32 {

--- a/src/input.rs
+++ b/src/input.rs
@@ -78,12 +78,12 @@ pub fn keys_to_pos(keys: &str, w: u32, h: u32) -> Option<(u32, u32)> {
     let row = hints.iter().position(|&c| c == c1)? as u32;
     let ncols = dynamic_cols(w);
     let nrows = dynamic_rows(h);
-    
+
     // Reject hints that map outside the currently rendered grid
     if col >= ncols || row >= nrows {
         return None;
     }
-    
+
     let cell_w = w / ncols;
     let cell_h = h / nrows;
     match chars.next() {

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -90,12 +90,12 @@ pub(super) fn handle_key<B: Backend>(
                     let row = hints().iter().position(|c| c == ch).unwrap_or(0) as u32;
                     let ncols = dynamic_cols(width);
                     let nrows = dynamic_rows(height);
-                    
+
                     // Reject if outside the currently rendered grid
                     if col >= ncols || row >= nrows {
                         return Ok(ModeTransition::Stay);
                     }
-                    
+
                     let cell_w = width / ncols;
                     let cell_h = height / nrows;
                     let cx = col * cell_w + cell_w / 2;

--- a/src/mode/recording.rs
+++ b/src/mode/recording.rs
@@ -54,12 +54,12 @@ pub(super) fn handle_key<B: Backend>(
                     let row = hints().iter().position(|c| c == ch).unwrap_or(0) as u32;
                     let ncols = dynamic_cols(width);
                     let nrows = dynamic_rows(height);
-                    
+
                     // Reject if outside the currently rendered grid
                     if col >= ncols || row >= nrows {
                         return Ok(ModeTransition::Stay);
                     }
-                    
+
                     let cell_w = width / ncols;
                     let cell_h = height / nrows;
                     let cx = col * cell_w + cell_w / 2;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,11 +1,72 @@
 use crate::{
-    config::colors,
+    config::{colors, font_size, panel_font_size, sub_hint_font_size},
     input::{dynamic_cols, dynamic_rows, hints, sub_cols, sub_hints, sub_rows, InputState},
 };
 use font8x8::UnicodeFonts;
 
-const FONT_SCALE: u32 = 2;
-const LINE_H: u32 = 24;
+fn line_height(scale: u32) -> u32 {
+    8 * scale + 8
+}
+
+fn char_width(scale: u32) -> u32 {
+    8 * scale
+}
+
+fn glyph_scale_for_cell(cell_w: u32, cell_h: u32, requested_scale: u32) -> u32 {
+    let fit_w = cell_w.saturating_sub(2) / 8;
+    let fit_h = cell_h.saturating_sub(2) / 8;
+    requested_scale.min(fit_w.min(fit_h).max(1))
+}
+
+fn glyph_bounds(ch: char) -> Option<(u32, u32, u32, u32)> {
+    let glyph = font8x8::BASIC_FONTS.get(ch).unwrap_or([0u8; 8]);
+    let mut min_x = 8u32;
+    let mut max_x = 0u32;
+    let mut min_y = 8u32;
+    let mut max_y = 0u32;
+
+    for (row, &bits) in glyph.iter().enumerate() {
+        for col in 0..8u32 {
+            if bits & (1 << col) != 0 {
+                min_x = min_x.min(col);
+                max_x = max_x.max(col);
+                min_y = min_y.min(row as u32);
+                max_y = max_y.max(row as u32);
+            }
+        }
+    }
+
+    (min_x < 8).then_some((min_x, max_x, min_y, max_y))
+}
+
+fn glyph_layout(ch: char, cell_w: u32, cell_h: u32, requested_scale: u32) -> (u32, u32, u32) {
+    let glyph_scale = glyph_scale_for_cell(cell_w, cell_h, requested_scale);
+    if let Some((min_x, max_x, min_y, max_y)) = glyph_bounds(ch) {
+        let active_w = (max_x - min_x + 1) * glyph_scale;
+        let active_h = (max_y - min_y + 1) * glyph_scale;
+        let offset_x = cell_w.saturating_sub(active_w) / 2;
+        let offset_y = cell_h.saturating_sub(active_h) / 2;
+        return (
+            glyph_scale,
+            offset_x.saturating_sub(min_x * glyph_scale),
+            offset_y.saturating_sub(min_y * glyph_scale),
+        );
+    }
+
+    let glyph_w = char_width(glyph_scale);
+    let glyph_h = 8 * glyph_scale;
+    (
+        glyph_scale,
+        cell_w.saturating_sub(glyph_w) / 2,
+        cell_h.saturating_sub(glyph_h) / 2,
+    )
+}
+
+fn subdivide_span(start: u32, span: u32, index: u32, count: u32) -> (u32, u32) {
+    let cell_start = start + index * span / count;
+    let cell_end = start + (index + 1) * span / count;
+    (cell_start, cell_end.saturating_sub(cell_start))
+}
 
 pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging: bool) {
     let mut c = Canvas { buf, w };
@@ -32,8 +93,9 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
     let nrows = dynamic_rows(h);
     let cell_w = w / ncols;
     let cell_h = h / nrows;
-    let char_w = 8 * FONT_SCALE;
-    let char_h = 8 * FONT_SCALE;
+    let scale = font_size();
+    let char_w = 8 * scale;
+    let char_h = 8 * scale;
     let gap = 3u32;
     let label_w = char_w * 2 + gap;
     let cell_normal = if dragging {
@@ -71,16 +133,17 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
 
             let lx = x + cell_w.saturating_sub(label_w) / 2;
             let ly = y + cell_h.saturating_sub(char_h) / 2;
-            c.draw_glyph(lx, ly, first_hint, c1, FONT_SCALE);
-            c.draw_glyph(lx + char_w + gap, ly, second_hint, c2, FONT_SCALE);
+            c.draw_glyph(lx, ly, first_hint, c1, scale);
+            c.draw_glyph(lx + char_w + gap, ly, second_hint, c2, scale);
         }
     }
 }
 
 pub fn render_rec_indicator(buf: &mut [u8], w: u32) {
+    let scale = font_size();
     let mut c = Canvas { buf, w };
-    c.fill_rect(8, 8, 56, 24, colors().rec_bg);
-    c.draw_text(12, 12, b"REC", colors().text_white, 2);
+    c.fill_rect(8, 8, 8 * scale * 4, line_height(scale), colors().rec_bg);
+    c.draw_text(12, 12, b"REC", colors().text_white, scale);
 }
 
 pub fn render_macro_bind_key(buf: &mut [u8], w: u32, h: u32) {
@@ -193,75 +256,90 @@ impl<'a> Canvas<'a> {
 
 /// Wraps a Canvas with layout tracking for centered popup panels.
 /// `rows` is the number of line-slots the content uses plus one for bottom
-/// breathing room; `panel_h = rows * LINE_H + 32`.
+/// breathing room; `panel_h = rows * line_height(scale) + 32` (clamped to screen height).
 struct Panel<'a> {
     c: Canvas<'a>,
     tx: u32, // left edge of text column
     px: u32, // left edge of panel (for row highlights)
     pw: u32, // panel width (for row highlights)
     ty: u32, // current y cursor
+    scale: u32,
 }
 
 impl<'a> Panel<'a> {
     fn new(buf: &'a mut [u8], w: u32, h: u32, rows: u32) -> Self {
         let mut c = Canvas { buf, w };
         c.clear();
-        let panel_h = rows * LINE_H + 32;
-        let panel_w = (w * 30 / 100).max(400).min(w);
-        let panel_x = (w - panel_w) / 2;
-        let panel_y = (h - panel_h) / 2;
+        let scale = panel_font_size();
+        let lh = line_height(scale);
+        let panel_h = (rows * lh + 32).min(h.saturating_sub(4));
+        let min_panel_chars = 30;
+        let panel_padding = 16 * scale;
+        let panel_min_w = min_panel_chars * char_width(scale) + panel_padding * 2;
+        let panel_w = (w * 30 / 100).max(panel_min_w).min(w);
+        let panel_x = (w.saturating_sub(panel_w)) / 2;
+        let panel_y = (h.saturating_sub(panel_h)) / 2;
         c.fill_rect(panel_x, panel_y, panel_w, panel_h, colors().panel_bg);
         Self {
             c,
-            tx: panel_x + 16,
+            tx: panel_x + panel_padding,
             px: panel_x,
             pw: panel_w,
-            ty: panel_y + 16,
+            ty: panel_y + panel_padding,
+            scale,
         }
     }
 
     fn text(&mut self, text: &[u8], color: [u8; 4]) -> &mut Self {
-        self.c.draw_text(self.tx, self.ty, text, color, 2);
-        self.ty += LINE_H;
+        self.c.draw_text(self.tx, self.ty, text, color, self.scale);
+        self.ty += line_height(self.scale);
         self
     }
 
     fn skip(&mut self) -> &mut Self {
-        self.ty += LINE_H;
+        self.ty += line_height(self.scale);
         self
     }
 
     fn text_with_char(&mut self, label: &[u8], ch: char, color: [u8; 4]) -> &mut Self {
-        self.c.draw_text(self.tx, self.ty, label, color, 2);
-        self.c
-            .draw_glyph(self.tx + label.len() as u32 * 16, self.ty, ch, color, 2);
-        self.ty += LINE_H;
+        self.c.draw_text(self.tx, self.ty, label, color, self.scale);
+        self.c.draw_glyph(
+            self.tx + label.len() as u32 * char_width(self.scale),
+            self.ty,
+            ch,
+            color,
+            self.scale,
+        );
+        self.ty += line_height(self.scale);
         self
     }
 
     /// Draws a `> chars_` text-input prompt line.
     fn input_line(&mut self, chars: &[char], color: [u8; 4]) -> &mut Self {
-        self.c.draw_text(self.tx, self.ty, b"> ", color, 2);
+        let cw = char_width(self.scale);
+        self.c.draw_text(self.tx, self.ty, b"> ", color, self.scale);
         self.c
-            .draw_chars(self.tx + 2 * 16, self.ty, chars, color, 2);
+            .draw_chars(self.tx + 2 * cw, self.ty, chars, color, self.scale);
         self.c.draw_glyph(
-            self.tx + (2 + chars.len() as u32) * 16,
+            self.tx + (2 + chars.len() as u32) * cw,
             self.ty,
             '_',
             color,
-            2,
+            self.scale,
         );
-        self.ty += LINE_H;
+        self.ty += line_height(self.scale);
         self
     }
 
     fn search_entry(&mut self, bind_key: Option<char>, name: &str, selected: bool) -> &mut Self {
+        let cw = char_width(self.scale);
+        let lh = line_height(self.scale);
         if selected {
             self.c.fill_rect(
                 self.px + 4,
                 self.ty.saturating_sub(2),
                 self.pw - 8,
-                LINE_H,
+                lh,
                 colors().selected_bg,
             );
         }
@@ -273,19 +351,29 @@ impl<'a> Panel<'a> {
         match bind_key {
             Some(k) => {
                 self.c
-                    .draw_text(self.tx, self.ty, b"[", colors().text_grey, 2);
+                    .draw_text(self.tx, self.ty, b"[", colors().text_grey, self.scale);
                 self.c
-                    .draw_glyph(self.tx + 16, self.ty, k, colors().text_grey, 2);
-                self.c
-                    .draw_text(self.tx + 2 * 16, self.ty, b"] ", colors().text_grey, 2);
+                    .draw_glyph(self.tx + cw, self.ty, k, colors().text_grey, self.scale);
+                self.c.draw_text(
+                    self.tx + 2 * cw,
+                    self.ty,
+                    b"] ",
+                    colors().text_grey,
+                    self.scale,
+                );
             }
             None => self
                 .c
-                .draw_text(self.tx, self.ty, b"[ ] ", colors().text_grey, 2),
+                .draw_text(self.tx, self.ty, b"[ ] ", colors().text_grey, self.scale),
         }
-        self.c
-            .draw_text(self.tx + 4 * 16, self.ty, name.as_bytes(), text_color, 2);
-        self.ty += LINE_H;
+        self.c.draw_text(
+            self.tx + 4 * cw,
+            self.ty,
+            name.as_bytes(),
+            text_color,
+            self.scale,
+        );
+        self.ty += line_height(self.scale);
         self
     }
 }
@@ -303,12 +391,12 @@ fn render_sub_grid(
     let sub_hints = sub_hints();
     let ncols = dynamic_cols(c.w);
     let nrows = dynamic_rows(h);
-    
+
     // Early return if main_col/main_row are outside the rendered grid
     if main_col >= ncols || main_row >= nrows {
         return;
     }
-    
+
     let cell_w = c.w / ncols;
     let cell_h = h / nrows;
     let cell_x = main_col * cell_w;
@@ -326,24 +414,34 @@ fn render_sub_grid(
     c.fill_rect(cell_x, cell_y, 1, cell_h, border);
     c.fill_rect(cell_x + cell_w - 1, cell_y, 1, cell_h, border);
 
-    let sub_cell_w = cell_w / nsub_cols;
-    let sub_cell_h = cell_h / nsub_rows;
-    let glyph_ox = sub_cell_w.saturating_sub(8) / 2;
-    let glyph_oy = sub_cell_h.saturating_sub(8) / 2;
-
+    let sub_hint_scale = sub_hint_font_size();
+    let col_spans: Vec<_> = (0..nsub_cols)
+        .map(|sub_col| subdivide_span(cell_x, cell_w, sub_col, nsub_cols))
+        .collect();
+    let row_spans: Vec<_> = (0..nsub_rows)
+        .map(|sub_row| subdivide_span(cell_y, cell_h, sub_row, nsub_rows))
+        .collect();
     for sub_row in 0..nsub_rows {
         for sub_col in 0..nsub_cols {
-            let x = cell_x + sub_col * sub_cell_w;
-            let y = cell_y + sub_row * sub_cell_h;
+            let (x, sub_cell_w) = col_spans[sub_col as usize];
+            let (y, sub_cell_h) = row_spans[sub_row as usize];
             let hint = sub_hints[(sub_row * nsub_cols + sub_col) as usize];
+            let (glyph_scale, glyph_ox, glyph_oy) =
+                glyph_layout(hint, sub_cell_w, sub_cell_h, sub_hint_scale);
             let is_selected = selected == Some((sub_col, sub_row));
             let (bg, text) = if is_selected {
                 (colors().cell_highlight, colors().text_highlight)
             } else {
                 (colors().sub_cell_normal, colors().text_first)
             };
-            c.fill_rect(x + 1, y + 1, sub_cell_w - 2, sub_cell_h - 2, bg);
-            c.draw_glyph(x + glyph_ox, y + glyph_oy, hint, text, 1);
+            c.fill_rect(
+                x + 1,
+                y + 1,
+                sub_cell_w.saturating_sub(2),
+                sub_cell_h.saturating_sub(2),
+                bg,
+            );
+            c.draw_glyph(x + glyph_ox, y + glyph_oy, hint, text, glyph_scale);
         }
     }
 }


### PR DESCRIPTION
based on issue https://github.com/museslabs/stochos/issues/12
## Summary
- Add configurable `font_size` option for high-DPI displays (4K monitors)
- Font scale now reads from config file instead of hardcoded value
## Changes
- **config.rs**: Add `font_size` field to Config struct (default: 2)
- **render.rs**: Use config-based font scaling for grid and UI panels
- **README.md**: Document new `font_size` config option
## Usage in config.toml
```toml
font_size = 3  # or higher 
