### PR TITLE
feat: add single-instance lock with --allow-multiple override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +115,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -130,6 +136,18 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -268,10 +286,11 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stochos"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "font8x8",
+ "nix",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ font8x8 = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
+nix = { version = "0.31", features = ["fs"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,44 @@ mod macro_store;
 mod mode;
 mod render;
 
+use nix::fcntl::{Flock, FlockArg};
+use std::fs::OpenOptions;
+
+struct LockGuard {
+    _lock: Flock<std::fs::File>, // RAII → lock held for lifetime
+}
+
+fn acquire_lock() -> anyhow::Result<Option<LockGuard>> {
+    let allow_multiple = std::env::args().any(|a| a == "--allow-multiple");
+    if allow_multiple {
+        return Ok(None);
+    }
+
+    let lock_path = "/tmp/stochos.lock";
+
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+
+    let lock = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => lock,
+
+        Err((_, nix::errno::Errno::EWOULDBLOCK)) => {
+            eprintln!("App already running (use --allow-multiple to override)");
+            std::process::exit(1);
+        }
+
+        Err((_, e)) => return Err(anyhow::anyhow!(e)),
+    };
+
+    Ok(Some(LockGuard { _lock: lock }))
+}
+
 fn main() -> anyhow::Result<()> {
+    let _lock = acquire_lock()?; // keep lock alive
+
     config::init();
 
     #[cfg(feature = "wayland")]


### PR DESCRIPTION
Prevent multiple instances from running simultaneously unless explicitly allowed via --allow-multiple.
for issue https://github.com/museslabs/stochos/issues/13