### PR TITLE
feat: add scroll sync with mouse movement to column centers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,8 @@ pub fn run<B: Backend>(backend: &mut B) -> anyhow::Result<()> {
         drag_origin: None,
     };
 
+    backend.move_mouse(w / 2, h / 2)?;
+
     mode.draw(backend, &mut pixels, w, h, &macro_store)?;
 
     while let Some(key) = backend.next_key()? {

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -7,10 +7,28 @@ mod recording;
 
 use crate::{
     backend::{Backend, KeyEvent},
+    config::config,
     input::{keys_to_pos, InputState},
     macro_store::{MacroAction, MacroStore},
     render::{render_grid, render_rec_indicator},
 };
+
+pub(super) fn move_to_column_center<B: Backend>(
+    backend: &mut B,
+    col: u32,
+    width: u32,
+    height: u32,
+) -> anyhow::Result<()> {
+    let cfg = config();
+    let ncols = cfg.dynamic_cols(width);
+    if col < ncols {
+        let cell_w = width / ncols;
+        let cx = col * cell_w + cell_w / 2;
+        let cy = height / 2;
+        backend.move_mouse(cx, cy)?;
+    }
+    Ok(())
+}
 
 pub enum ModeTransition {
     Stay,

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -6,7 +6,7 @@ use crate::{
     config::config,
     input::InputState,
     macro_store::MacroAction,
-    mode::{draw_grid, ModeTransition},
+    mode::{draw_grid, move_to_column_center, ModeTransition},
 };
 
 pub(super) fn handle_key<B: Backend>(
@@ -53,6 +53,7 @@ pub(super) fn handle_key<B: Backend>(
                 InputState::Ready { .. } | InputState::SubFirst { .. }
             ) =>
         {
+            backend.move_mouse(width / 2, height / 2)?;
             Ok(ModeTransition::Enter(Mode::Normal {
                 input_state: InputState::First,
                 target: None,
@@ -82,11 +83,16 @@ pub(super) fn handle_key<B: Backend>(
         {
             let cfg = config();
             match input_state {
-                InputState::First => Ok(ModeTransition::Enter(Mode::Normal {
-                    input_state: InputState::Second(*ch),
-                    target,
-                    drag_origin,
-                })),
+                InputState::First => {
+                    let col = cfg.hints().iter().position(|c| c == ch).unwrap_or(0) as u32;
+                    move_to_column_center(backend, col, width, height)?;
+
+                    Ok(ModeTransition::Enter(Mode::Normal {
+                        input_state: InputState::Second(*ch),
+                        target,
+                        drag_origin,
+                    }))
+                }
                 InputState::Second(first) => {
                     let col = cfg.hints().iter().position(|c| c == first).unwrap_or(0) as u32;
                     let row = cfg.hints().iter().position(|c| c == ch).unwrap_or(0) as u32;

--- a/src/mode/recording.rs
+++ b/src/mode/recording.rs
@@ -3,7 +3,7 @@ use crate::{
     config::config,
     input::InputState,
     macro_store::MacroAction,
-    mode::{draw_grid, Mode, ModeTransition},
+    mode::{draw_grid, move_to_column_center, Mode, ModeTransition},
 };
 
 pub(super) fn handle_key<B: Backend>(
@@ -21,6 +21,7 @@ pub(super) fn handle_key<B: Backend>(
         KeyEvent::Undo => Ok(ModeTransition::Back),
         KeyEvent::MacroRecord => {
             if recorded_actions.is_empty() {
+                backend.move_mouse(width / 2, height / 2)?;
                 Ok(ModeTransition::Enter(Mode::Normal {
                     input_state: InputState::First,
                     target: None,
@@ -32,11 +33,14 @@ pub(super) fn handle_key<B: Backend>(
                 }))
             }
         }
-        KeyEvent::Close => Ok(ModeTransition::Enter(Mode::Normal {
-            input_state: InputState::First,
-            target: None,
-            drag_origin: None,
-        })),
+        KeyEvent::Close => {
+            backend.move_mouse(width / 2, height / 2)?;
+            Ok(ModeTransition::Enter(Mode::Normal {
+                input_state: InputState::First,
+                target: None,
+                drag_origin: None,
+            }))
+        }
         KeyEvent::Char(ch)
             if config().hints().contains(ch)
                 || (matches!(input_state, InputState::SubFirst { .. })
@@ -44,13 +48,18 @@ pub(super) fn handle_key<B: Backend>(
         {
             let cfg = config();
             match input_state {
-                InputState::First => Ok(ModeTransition::Enter(Mode::MacroRecording {
-                    input_state: InputState::Second(*ch),
-                    target,
-                    drag_origin,
-                    recorded_actions: recorded_actions.to_vec(),
-                    drag_start_keys: drag_start_keys.to_owned(),
-                })),
+                InputState::First => {
+                    let col = cfg.hints().iter().position(|c| c == ch).unwrap_or(0) as u32;
+                    move_to_column_center(backend, col, width, height)?;
+
+                    Ok(ModeTransition::Enter(Mode::MacroRecording {
+                        input_state: InputState::Second(*ch),
+                        target,
+                        drag_origin,
+                        recorded_actions: recorded_actions.to_vec(),
+                        drag_start_keys: drag_start_keys.to_owned(),
+                    }))
+                }
                 InputState::Second(first) => {
                     let col = cfg.hints().iter().position(|c| c == first).unwrap_or(0) as u32;
                     let row = cfg.hints().iter().position(|c| c == ch).unwrap_or(0) as u32;
@@ -174,6 +183,7 @@ pub(super) fn handle_key<B: Backend>(
             }))
         }
         KeyEvent::Char('/') if drag_origin.is_some() => {
+            backend.move_mouse(width / 2, height / 2)?;
             Ok(ModeTransition::Enter(Mode::MacroRecording {
                 input_state: InputState::First,
                 target: None,
@@ -188,6 +198,7 @@ pub(super) fn handle_key<B: Backend>(
                 InputState::Ready { .. } | InputState::SubFirst { .. }
             ) =>
         {
+            backend.move_mouse(width / 2, height / 2)?;
             Ok(ModeTransition::Enter(Mode::MacroRecording {
                 input_state: InputState::First,
                 target,


### PR DESCRIPTION
based on issue https://github.com/museslabs/stochos/issues/20

this was the issue

https://github.com/user-attachments/assets/1f106772-e7ee-4b4e-a92f-a0d65991dba0


---

solution : taking column center 

https://github.com/user-attachments/assets/dbcfb051-22a8-4cdf-85f2-01acebfb149e

