### PR TITLE
feat: add --print-default-config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All keys are configurable (see Configuration below).
 |------|--------|
 | `--bisect` | Start the overlay directly in bisect mode |
 | `--allow-multiple` | Skip the single-instance lock |
+| `--print-default-config` | Print the default config (TOML) to stdout and exit. Diff against your `config.toml` to discover options added by newer versions |
 
 ### Bisect mode
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,11 @@ pub struct Args {
     /// Allow multiple concurrent instances
     #[arg(long)]
     pub allow_multiple: bool,
+    #[arg(
+        long,
+        help = "Print the default config (TOML) to stdout and exit. Diff against your config.toml to see new options."
+    )]
+    pub print_default_config: bool,
 }
 
 impl Args {

--- a/src/config.rs
+++ b/src/config.rs
@@ -428,6 +428,10 @@ impl Default for Config {
 }
 
 impl Config {
+    pub fn default_toml() -> anyhow::Result<String> {
+        Ok(toml::to_string_pretty(&Config::default())?)
+    }
+
     fn load() -> Self {
         let path = config_path();
         match std::fs::read_to_string(&path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,12 @@ fn acquire_lock(allow_multiple: bool) -> anyhow::Result<Option<LockGuard>> {
 
 fn main() -> anyhow::Result<()> {
     let args = cli::Args::parse();
+
+    if args.print_default_config {
+        print!("{}", config::Config::default_toml()?);
+        return Ok(());
+    }
+
     let _lock = acquire_lock(args.allow_multiple)?; // keep lock alive
 
     config::init();


### PR DESCRIPTION

- add a config helper to serialize the default config as toml
- add a --print-default-config cli flag and document it
- print the default config and exit before normal startup
