### PR TITLE
feat(macros): record and replay per-action wait times

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Record multi-step mouse sequences for replay.
 
 **Replay:** Press `@` then the bind key. Or press Tab to search by name, then Enter to select.
 
-Macros are resolution-independent and stored at `~/.config/stochos/macros.json`.
+**Timing.** Stochos captures the delay between each recorded action and replays at the same rhythm, so animations and page loads have time to settle. The first action has no wait (you weren't waiting for anything to start the macro). On replay, delays are scaled by `macros.playback_speed` in `config.toml` (default `1.0`, `2.0` plays twice as fast, `0.0` or negative plays instantly with no waits). You can also hand-edit the per-action `wait_ms` values in `macros.json` for fine-grained tuning.
+
+Macros are resolution-independent and stored at `~/.config/stochos/macros.json`. Macros recorded before this version still load and replay (without inter-action delays).
 
 ## Configuration
 
@@ -148,6 +150,9 @@ hints = ["a", "s", "d", "f"]  # One per cell, row-major (length must be >= rows 
 rows = 2
 cols = 2
 min_cell_size = 16  # Stop subdividing once a cell would be smaller than this, in pixels
+
+[macros]
+playback_speed = 1.0  # 1.0 = recorded speed, 2.0 = twice as fast, 0.0 or negative = instant (no waits)
 
 [keys]
 normal = "n"
@@ -202,6 +207,10 @@ border_dragging = "#e91e63ff"    # Material Pink (strong attention grabber)
 - `hints` sets the characters for each bisect cell, in row-major order. Must contain at least `rows * cols` entries; extras are ignored.
 - `rows` and `cols` set the grid shape used at every subdivision level (default 2x2).
 - `min_cell_size` is the pixel floor at which subdivision stops. The glyph scale auto-shrinks to fit the cell, so lowering this lets you reach tiny regions.
+
+### Macros
+
+- `playback_speed` scales the per-action delays recorded into each macro. `1.0` plays at the recorded rhythm, `2.0` plays twice as fast, `0.5` plays at half speed. Setting it to `0.0` (or any negative value) disables waits entirely for instant playback. Default is `1.0`.
 
 ### Keys
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,7 +42,24 @@ pub fn run<B: Backend>(backend: &mut B, initial: InitialMode) -> anyhow::Result<
             }
             ModeTransition::Back => {
                 if let Some(prev) = transition_stack.pop() {
-                    mode = prev;
+                    // Keep the timing baseline only for plain cell-selection undo within
+                    // recording: same action count AND same drag state. Anything else (action
+                    // dropped, drag attempt abandoned, return from a foreign mode) is a
+                    // discarded attempt whose elapsed time shouldn't count toward the next
+                    // wait_ms.
+                    let keep = matches!(
+                        (&mode, &prev),
+                        (
+                            Mode::MacroRecording {
+                                recorded_actions: cur, drag_origin: cur_drag, ..
+                            },
+                            Mode::MacroRecording {
+                                recorded_actions: prev_acts, drag_origin: prev_drag, ..
+                            },
+                        ) if cur.len() == prev_acts.len()
+                            && cur_drag.is_some() == prev_drag.is_some()
+                    );
+                    mode = if keep { prev } else { prev.reset_timing_baseline() };
                     mode.draw(backend, &mut pixels, w, h, &macro_store)?;
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,11 +409,27 @@ impl Default for BisectConfig {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
+pub struct MacrosConfig {
+    /// 1.0 = recorded speed, 2.0 = twice as fast, 0.0 or negative = instant (no waits).
+    pub playback_speed: f32,
+}
+
+impl Default for MacrosConfig {
+    fn default() -> Self {
+        Self {
+            playback_speed: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub grid: GridConfig,
     pub bisect: BisectConfig,
     pub keys: KeyBindings,
     pub colors: Colors,
+    pub macros: MacrosConfig,
     pub font_size: u32,
     pub sub_hint_font_size: Option<u32>,
     pub panel_font_size: Option<u32>,
@@ -426,6 +442,7 @@ impl Default for Config {
             bisect: BisectConfig::default(),
             keys: KeyBindings::default(),
             colors: Colors::default(),
+            macros: MacrosConfig::default(),
             font_size: 2,
             sub_hint_font_size: None,
             panel_font_size: None,
@@ -469,6 +486,14 @@ impl Config {
         self.panel_font_size
             .or(self.sub_hint_font_size)
             .map_or_else(|| self.font_size(), clamp_scale)
+    }
+
+    pub fn macro_playback_speed(&self) -> f32 {
+        if self.macros.playback_speed.is_nan() {
+            1.0
+        } else {
+            self.macros.playback_speed
+        }
     }
 
     pub fn hints(&self) -> &[char] {

--- a/src/macro_store.rs
+++ b/src/macro_store.rs
@@ -1,14 +1,52 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Clone)]
-pub enum MacroAction {
+pub enum MacroActionKind {
     Move(String),
     Click(String),
     DoubleClick(String),
     RightClick(String),
     Drag(String, String),
+}
+
+#[derive(Serialize, Clone)]
+pub struct MacroAction {
+    pub kind: MacroActionKind,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub wait_ms: u64,
+}
+
+fn is_zero(n: &u64) -> bool {
+    *n == 0
+}
+
+impl MacroAction {
+    pub fn new(kind: MacroActionKind, wait_ms: u64) -> Self {
+        Self { kind, wait_ms }
+    }
+}
+
+impl<'de> Deserialize<'de> for MacroAction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Accept both the new `{ "kind": ..., "wait_ms": N }` shape and the
+        // legacy bare-enum shape (e.g. `{ "Click": "as" }`) from older macros.json files.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            New {
+                kind: MacroActionKind,
+                #[serde(default)]
+                wait_ms: u64,
+            },
+            Legacy(MacroActionKind),
+        }
+        Ok(match Repr::deserialize(deserializer)? {
+            Repr::New { kind, wait_ms } => MacroAction { kind, wait_ms },
+            Repr::Legacy(kind) => MacroAction { kind, wait_ms: 0 },
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -6,11 +6,13 @@ mod macro_search;
 mod normal;
 mod recording;
 
+use std::time::{Duration, Instant};
+
 use crate::{
     backend::{Backend, KeyEvent},
     config::config,
     input::{keys_to_pos, InputState},
-    macro_store::{MacroAction, MacroStore},
+    macro_store::{MacroAction, MacroActionKind, MacroStore},
     render::{render_grid, render_rec_indicator},
 };
 
@@ -54,6 +56,7 @@ pub enum Mode {
         drag_origin: Option<(u32, u32)>,
         recorded_actions: Vec<MacroAction>,
         drag_start_keys: String,
+        last_action_at: Option<Instant>,
     },
     MacroBindKey {
         actions: Vec<MacroAction>,
@@ -71,6 +74,27 @@ pub enum Mode {
 }
 
 impl Mode {
+    pub fn reset_timing_baseline(self) -> Self {
+        match self {
+            Mode::MacroRecording {
+                input_state,
+                target,
+                drag_origin,
+                recorded_actions,
+                drag_start_keys,
+                last_action_at,
+            } => Mode::MacroRecording {
+                input_state,
+                target,
+                drag_origin,
+                recorded_actions,
+                drag_start_keys,
+                last_action_at: last_action_at.map(|_| Instant::now()),
+            },
+            other => other,
+        }
+    }
+
     pub fn handle_key<B: Backend>(
         &self,
         width: u32,
@@ -100,6 +124,7 @@ impl Mode {
                 drag_origin,
                 recorded_actions,
                 drag_start_keys,
+                last_action_at,
             } => recording::handle_key(
                 width,
                 height,
@@ -110,6 +135,7 @@ impl Mode {
                 *drag_origin,
                 recorded_actions,
                 drag_start_keys,
+                *last_action_at,
             ),
             Mode::MacroBindKey { actions } => macro_bind_key::handle_key(key, actions),
             Mode::MacroName {
@@ -200,29 +226,36 @@ pub(super) fn replay_macro(
     h: u32,
     backend: &mut dyn Backend,
 ) -> anyhow::Result<()> {
+    let speed = config().macro_playback_speed();
     for action in actions {
-        match action {
-            MacroAction::Move(keys) => {
+        if speed > 0.0 && action.wait_ms > 0 {
+            let scaled = (action.wait_ms as f32 / speed).round() as u64;
+            if scaled > 0 {
+                std::thread::sleep(Duration::from_millis(scaled));
+            }
+        }
+        match &action.kind {
+            MacroActionKind::Move(keys) => {
                 if let Some((x, y)) = keys_to_pos(keys, w, h) {
                     backend.move_mouse(x, y)?;
                 }
             }
-            MacroAction::Click(keys) => {
+            MacroActionKind::Click(keys) => {
                 if let Some((x, y)) = keys_to_pos(keys, w, h) {
                     backend.click(x, y)?;
                 }
             }
-            MacroAction::DoubleClick(keys) => {
+            MacroActionKind::DoubleClick(keys) => {
                 if let Some((x, y)) = keys_to_pos(keys, w, h) {
                     backend.double_click(x, y)?;
                 }
             }
-            MacroAction::RightClick(keys) => {
+            MacroActionKind::RightClick(keys) => {
                 if let Some((x, y)) = keys_to_pos(keys, w, h) {
                     backend.right_click(x, y)?;
                 }
             }
-            MacroAction::Drag(start_keys, end_keys) => {
+            MacroActionKind::Drag(start_keys, end_keys) => {
                 if let (Some((x1, y1)), Some((x2, y2))) =
                     (keys_to_pos(start_keys, w, h), keys_to_pos(end_keys, w, h))
                 {

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -5,7 +5,7 @@ use crate::{
     backend::{Backend, KeyEvent},
     config::{config, Key},
     input::InputState,
-    macro_store::MacroAction,
+    macro_store::{MacroAction, MacroActionKind},
     mode::{draw_grid, move_to_column_center, ModeTransition},
 };
 
@@ -74,6 +74,7 @@ pub(super) fn handle_key<B: Backend>(
                 drag_origin: None,
                 recorded_actions: Vec::new(),
                 drag_start_keys: String::new(),
+                last_action_at: None,
             }))
         }
         KeyEvent::Char(ch)
@@ -155,7 +156,10 @@ pub(super) fn handle_key<B: Backend>(
             ) =>
         {
             Ok(ModeTransition::Enter(Mode::MacroBindKey {
-                actions: vec![MacroAction::Click(input_state.keys())],
+                actions: vec![MacroAction::new(
+                    MacroActionKind::Click(input_state.keys()),
+                    0,
+                )],
             }))
         }
         KeyEvent::MacroMenu

--- a/src/mode/recording.rs
+++ b/src/mode/recording.rs
@@ -1,10 +1,17 @@
+use std::time::Instant;
+
 use crate::{
     backend::{Backend, KeyEvent},
     config::config,
     input::InputState,
-    macro_store::MacroAction,
+    macro_store::{MacroAction, MacroActionKind},
     mode::{draw_grid, move_to_column_center, Mode, ModeTransition},
 };
+
+fn elapsed_ms(last: Option<Instant>, now: Instant) -> u64 {
+    last.map(|t| now.duration_since(t).as_millis() as u64)
+        .unwrap_or(0)
+}
 
 pub(super) fn handle_key<B: Backend>(
     width: u32,
@@ -16,6 +23,7 @@ pub(super) fn handle_key<B: Backend>(
     drag_origin: Option<(u32, u32)>,
     recorded_actions: &[MacroAction],
     drag_start_keys: &str,
+    last_action_at: Option<Instant>,
 ) -> anyhow::Result<ModeTransition> {
     match key {
         KeyEvent::Undo => Ok(ModeTransition::Back),
@@ -58,6 +66,7 @@ pub(super) fn handle_key<B: Backend>(
                         drag_origin,
                         recorded_actions: recorded_actions.to_vec(),
                         drag_start_keys: drag_start_keys.to_owned(),
+                        last_action_at,
                     }))
                 }
                 InputState::Second(first) => {
@@ -84,6 +93,7 @@ pub(super) fn handle_key<B: Backend>(
                         drag_origin,
                         recorded_actions: recorded_actions.to_vec(),
                         drag_start_keys: drag_start_keys.to_owned(),
+                        last_action_at,
                     }))
                 }
                 InputState::SubFirst { col, row } => {
@@ -112,6 +122,7 @@ pub(super) fn handle_key<B: Backend>(
                             drag_origin,
                             recorded_actions: recorded_actions.to_vec(),
                             drag_start_keys: drag_start_keys.to_owned(),
+                            last_action_at,
                         }));
                     }
                     Ok(ModeTransition::Stay)
@@ -124,19 +135,27 @@ pub(super) fn handle_key<B: Backend>(
         {
             let (x, y) = target.unwrap();
             let current_keys = input_state.keys();
+            let now = Instant::now();
+            let wait_ms = elapsed_ms(last_action_at, now);
             let mut new_actions = recorded_actions.to_vec();
             match key {
                 KeyEvent::Click => {
                     backend.click(x, y)?;
-                    new_actions.push(MacroAction::Click(current_keys));
+                    new_actions.push(MacroAction::new(MacroActionKind::Click(current_keys), wait_ms));
                 }
                 KeyEvent::DoubleClick => {
                     backend.double_click(x, y)?;
-                    new_actions.push(MacroAction::DoubleClick(current_keys));
+                    new_actions.push(MacroAction::new(
+                        MacroActionKind::DoubleClick(current_keys),
+                        wait_ms,
+                    ));
                 }
                 KeyEvent::RightClick => {
                     backend.right_click(x, y)?;
-                    new_actions.push(MacroAction::RightClick(current_keys));
+                    new_actions.push(MacroAction::new(
+                        MacroActionKind::RightClick(current_keys),
+                        wait_ms,
+                    ));
                 }
                 _ => {}
             }
@@ -147,14 +166,20 @@ pub(super) fn handle_key<B: Backend>(
                 drag_origin: None,
                 recorded_actions: new_actions,
                 drag_start_keys: String::new(),
+                last_action_at: Some(now),
             }))
         }
         KeyEvent::Click | KeyEvent::DoubleClick if target.is_some() => {
             let (x, y) = target.unwrap();
             let current_keys = input_state.keys();
+            let now = Instant::now();
+            let wait_ms = elapsed_ms(last_action_at, now);
             let mut new_actions = recorded_actions.to_vec();
             backend.drag_select(drag_origin.unwrap().0, drag_origin.unwrap().1, x, y)?;
-            new_actions.push(MacroAction::Drag(drag_start_keys.to_owned(), current_keys));
+            new_actions.push(MacroAction::new(
+                MacroActionKind::Drag(drag_start_keys.to_owned(), current_keys),
+                wait_ms,
+            ));
             backend.reopen()?;
             Ok(ModeTransition::Enter(Mode::MacroRecording {
                 input_state: InputState::First,
@@ -162,6 +187,7 @@ pub(super) fn handle_key<B: Backend>(
                 drag_origin: None,
                 recorded_actions: new_actions,
                 drag_start_keys: String::new(),
+                last_action_at: Some(now),
             }))
         }
         KeyEvent::MacroMenu
@@ -172,14 +198,20 @@ pub(super) fn handle_key<B: Backend>(
                     InputState::SubFirst { .. } | InputState::Ready { .. }
                 ) =>
         {
+            let now = Instant::now();
+            let wait_ms = elapsed_ms(last_action_at, now);
             let mut new_actions = recorded_actions.to_vec();
-            new_actions.push(MacroAction::Move(input_state.keys()));
+            new_actions.push(MacroAction::new(
+                MacroActionKind::Move(input_state.keys()),
+                wait_ms,
+            ));
             Ok(ModeTransition::Enter(Mode::MacroRecording {
                 input_state: InputState::First,
                 target: None,
                 drag_origin: None,
                 recorded_actions: new_actions,
                 drag_start_keys: String::new(),
+                last_action_at: Some(now),
             }))
         }
         KeyEvent::Char('/') if drag_origin.is_some() => {
@@ -190,6 +222,7 @@ pub(super) fn handle_key<B: Backend>(
                 drag_origin: None,
                 recorded_actions: recorded_actions.to_vec(),
                 drag_start_keys: String::new(),
+                last_action_at: last_action_at.map(|_| Instant::now()),
             }))
         }
         KeyEvent::Char('/')
@@ -205,6 +238,7 @@ pub(super) fn handle_key<B: Backend>(
                 drag_origin: target,
                 recorded_actions: recorded_actions.to_vec(),
                 drag_start_keys: input_state.keys(),
+                last_action_at,
             }))
         }
         _ => Ok(ModeTransition::Stay),


### PR DESCRIPTION
- capture elapsed time between recorded actions as wait_ms and replay at the same rhythm
- add macros.playback_speed config to scale delays (0.0 or negative = instant)
- accept legacy macro entries without wait_ms so older macros.json files keep working
- reset timing baseline on undo of dropped actions so discarded attempts don't inflate the next wait
