### PR TITLE
feat: add free mode startup at current cursor position

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use crate::mode::{Mode, ModeTransition};
 pub enum InitialMode {
     Normal,
     Bisect,
-    Free,
+    Free { at_cursor: bool },
 }
 
 pub fn run<B: Backend>(backend: &mut B, initial: InitialMode) -> anyhow::Result<()> {
@@ -16,6 +16,8 @@ pub fn run<B: Backend>(backend: &mut B, initial: InitialMode) -> anyhow::Result<
     let mut pixels = vec![0u8; (w * h * 4) as usize];
     let mut macro_store = MacroStore::load();
     let mut transition_stack: Vec<Mode> = Vec::new();
+
+    let mut warp_to_center = true;
     let mut mode = match initial {
         InitialMode::Normal => Mode::Normal {
             input_state: InputState::First,
@@ -25,14 +27,35 @@ pub fn run<B: Backend>(backend: &mut B, initial: InitialMode) -> anyhow::Result<
         InitialMode::Bisect => Mode::Bisect {
             region: (0, 0, w, h),
         },
-        InitialMode::Free => Mode::Free {
-            x: w / 2,
-            y: h / 2,
-            speed: config().free.base_speed.max(1),
-        },
+        InitialMode::Free { at_cursor } => {
+            let (x, y) = if at_cursor {
+                match backend.cursor_position()? {
+                    Some(pos) => {
+                        warp_to_center = false;
+                        pos
+                    }
+                    None => {
+                        eprintln!(
+                            "stochos: cursor position unavailable on this backend; \
+                             falling back to screen center for free mode."
+                        );
+                        (w / 2, h / 2)
+                    }
+                }
+            } else {
+                (w / 2, h / 2)
+            };
+            Mode::Free {
+                x,
+                y,
+                speed: config().free.base_speed.max(1),
+            }
+        }
     };
 
-    backend.move_mouse(w / 2, h / 2)?;
+    if warp_to_center {
+        backend.move_mouse(w / 2, h / 2)?;
+    }
 
     mode.draw(backend, &mut pixels, w, h, &macro_store)?;
 

--- a/src/backend/macos.rs
+++ b/src/backend/macos.rs
@@ -110,6 +110,8 @@ unsafe extern "C" {
     fn CGAssociateMouseAndMouseCursorPosition(connected: bool) -> i32;
 
     fn CGEventSourceCreate(state_id: i32) -> CGEventSourceRef;
+    fn CGEventCreate(source: CGEventSourceRef) -> CGEventRef;
+    fn CGEventGetLocation(event: CGEventRef) -> CGPoint;
     fn CGEventCreateMouseEvent(
         source: CGEventSourceRef,
         mouse_type: u32,
@@ -606,6 +608,20 @@ impl Backend for MacosBackend {
     fn move_mouse(&mut self, x: u32, y: u32) -> Result<()> {
         self.move_cursor(x, y);
         Ok(())
+    }
+
+    fn cursor_position(&mut self) -> Result<Option<(u32, u32)>> {
+        unsafe {
+            let evt = CGEventCreate(ptr::null_mut());
+            if evt.is_null() {
+                return Ok(None);
+            }
+            let pt = CGEventGetLocation(evt);
+            CFRelease(evt);
+            let x = pt.x.clamp(0.0, (self.screen_w.saturating_sub(1)) as f64) as u32;
+            let y = pt.y.clamp(0.0, (self.screen_h.saturating_sub(1)) as f64) as u32;
+            Ok(Some((x, y)))
+        }
     }
 
     fn click(&mut self, x: u32, y: u32) -> Result<()> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -34,6 +34,10 @@ pub trait Backend {
     /// Move the mouse pointer to an absolute position.
     fn move_mouse(&mut self, x: u32, y: u32) -> Result<()>;
 
+    /// Current pointer position in screen coordinates. Returns `None` on
+    /// backends that can't query it (e.g. Wayland has no standard protocol).
+    fn cursor_position(&mut self) -> Result<Option<(u32, u32)>>;
+
     /// Tear down the overlay, click at (x, y), then return.
     fn click(&mut self, x: u32, y: u32) -> Result<()>;
 

--- a/src/backend/wayland.rs
+++ b/src/backend/wayland.rs
@@ -173,6 +173,12 @@ impl Backend for WaylandBackend {
         Ok(())
     }
 
+    fn cursor_position(&mut self) -> Result<Option<(u32, u32)>> {
+        // Wayland has no standard protocol for clients to query global cursor
+        // position. `zwlr_virtual_pointer_v1` is write-only.
+        Ok(None)
+    }
+
     /// Destroy the overlay so the compositor removes it from the surface stack,
     /// then re-send motion to trigger a focus update, then click.
     fn click(&mut self, x: u32, y: u32) -> Result<()> {

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -217,6 +217,18 @@ impl Backend for X11Backend {
         self.warp_and_sync(x, y)
     }
 
+    fn cursor_position(&mut self) -> Result<Option<(u32, u32)>> {
+        let reply = self
+            .conn
+            .query_pointer(self.root)
+            .context("query_pointer")?
+            .reply()
+            .context("query_pointer reply")?;
+        let x = (reply.root_x as i32).clamp(0, self.screen_w as i32 - 1) as u32;
+        let y = (reply.root_y as i32).clamp(0, self.screen_h as i32 - 1) as u32;
+        Ok(Some((x, y)))
+    }
+
     fn click(&mut self, x: u32, y: u32) -> Result<()> {
         self.teardown()?;
         self.warp_and_sync(x, y)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use crate::app::InitialMode;
+use crate::config::config;
 
 #[derive(Parser)]
 #[command(version, about = "Keyboard-driven mouse overlay")]
@@ -12,6 +13,11 @@ pub struct Args {
     /// Start in free mode (move the cursor manually)
     #[arg(long, group = "mode")]
     pub free: bool,
+
+    /// Start in free mode at the current cursor position.
+    /// Implies --free; overrides the `free.start_at_cursor` config setting.
+    #[arg(long, conflicts_with = "bisect")]
+    pub free_at_cursor: bool,
 
     /// Allow multiple concurrent instances
     #[arg(long)]
@@ -29,8 +35,9 @@ impl Args {
             return InitialMode::Bisect;
         }
 
-        if self.free {
-            return InitialMode::Free;
+        if self.free || self.free_at_cursor {
+            let at_cursor = self.free_at_cursor || config().free.start_at_cursor;
+            return InitialMode::Free { at_cursor };
         }
 
         InitialMode::Normal

--- a/src/config.rs
+++ b/src/config.rs
@@ -445,6 +445,7 @@ pub struct FreeConfig {
     pub slow_multiplier: f32,
     pub min_speed: u32,
     pub max_speed: u32,
+    pub start_at_cursor: bool,
 }
 
 impl Default for FreeConfig {
@@ -461,6 +462,7 @@ impl Default for FreeConfig {
             slow_multiplier: 3.0,
             min_speed: 1,
             max_speed: 500,
+            start_at_cursor: false,
         }
     }
 }


### PR DESCRIPTION
  - add backend cursor position query
  - initialize free mode at the current cursor when requested
  - skip recentering when free mode starts at the current cursor
  - add x11 and macos cursor position support
  - return unavailable for cursor position queries on wayland
  - add --free-at-cursor cli flag
  - add free.start_at_cursor config option
