### PR TITLE
fix(nix): add libxkbcommon to buildInputs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,6 +4,7 @@
   stdenv,
   wayland,
   libx11,
+  libxkbcommon,
   ...
 }: let
   unfilteredRoot = ../.;
@@ -11,6 +12,7 @@
   libs = [
     wayland
     libx11
+    libxkbcommon
   ];
   libsPath = lib.makeLibraryPath libs;
 


### PR DESCRIPTION
The `xkbcommon` crate was added to both default features in 0eb4603 (`wayland` and `x11`, with `default = ["wayland", "x11"]`), so every default build now links against the system `libxkbcommon`. `nix/package.nix` wasn't updated to match and still only lists `wayland` and `libx11` in `buildInputs`, so the Nix flake build fails at the link step:

```
  ld: cannot find -lxkbcommon: No such file or directory
  collect2: error: ld returned 1 exit status
  error: could not compile stochos (bin "stochos") due to 1 previous error
```

  This is the Nix-side equivalent of the CI fix already merged in 82789a2 (`fix(ci): install libxkbcommon-dev for xkbcommon linking`) - the same missing dependency, just for the Nix build path. The regression first shipped in v0.6.1 and is still present on `main`.

  This PR adds `libxkbcommon` to the `libs` list, which covers both `buildInputs` (fixing the link) and `libsPath`, so the existing `postFixup` rpath patch resolves it at runtime too.