### PR TITLE
Draw configurable border on the main grid

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -351,6 +351,17 @@ pub struct Colors {
     #[serde(with = "from_hex")]
     pub border_dragging: [u8; 4],
 
+    /// Inner grid lines (between cells) of the main grid. `None` -> invisible,
+    /// preserving the current borderless look. The outer edge is not drawn here.
+    #[serde(with = "from_hex_opt")]
+    pub separator: Option<[u8; 4]>,
+    /// Inner grid lines (between sub-cells) in the sub-grid. `None` -> invisible.
+    #[serde(with = "from_hex_opt")]
+    pub separator_subgrid: Option<[u8; 4]>,
+    /// Inner grid lines (between cells) in bisect mode. `None` -> invisible.
+    #[serde(with = "from_hex_opt")]
+    pub separator_bisect: Option<[u8; 4]>,
+
     #[serde(with = "from_hex")]
     pub crosshair: [u8; 4],
 
@@ -365,16 +376,18 @@ pub struct Colors {
 }
 mod from_hex {
     use serde::{Deserialize, Deserializer, Serializer};
-    pub fn serialize<S: Serializer>(color: &[u8; 4], serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!(
+
+    /// Format a BGRA color as #RRGGBBAA.
+    pub fn to_hex(color: &[u8; 4]) -> String {
+        format!(
             "#{:02X}{:02X}{:02X}{:02X}",
             color[2], color[1], color[0], color[3]
-        ))
+        )
     }
-    ///Deserialize from #RRGGBBAA  to [BB,GG,RR,AA]
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 4], D::Error> {
-        let s = String::deserialize(deserializer)?;
-        let hex = s.trim_start_matches("#");
+
+    /// Parse #RRGGBBAA (or #RRGGBB) into [BB, GG, RR, AA].
+    pub fn parse(s: &str) -> [u8; 4] {
+        let hex = s.trim_start_matches('#');
         let rgba = match hex.len() {
             6 => u32::from_str_radix(hex, 16)
                 .map(|a| a << 8)
@@ -382,12 +395,41 @@ mod from_hex {
             8 => u32::from_str_radix(hex, 16).unwrap_or_default(),
             _ => 0,
         };
-        Ok([
+        [
             ((rgba & 0x0000FF00) >> 8) as u8,
             ((rgba & 0x00FF0000) >> 16) as u8,
             ((rgba & 0xFF000000) >> 24) as u8,
             (rgba & 0x000000FF) as u8,
-        ])
+        ]
+    }
+
+    pub fn serialize<S: Serializer>(color: &[u8; 4], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&to_hex(color))
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 4], D::Error> {
+        Ok(parse(&String::deserialize(deserializer)?))
+    }
+}
+
+/// Like `from_hex`, but for optional colors: an absent key stays `None` (so the
+/// draw site can stay invisible / fall back), a present key parses as usual.
+mod from_hex_opt {
+    use super::from_hex;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        color: &Option<[u8; 4]>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match color {
+            Some(c) => serializer.serialize_str(&from_hex::to_hex(c)),
+            None => serializer.serialize_none(),
+        }
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<[u8; 4]>, D::Error> {
+        Ok(Option::<String>::deserialize(deserializer)?.map(|s| from_hex::parse(&s)))
     }
 }
 
@@ -415,6 +457,9 @@ impl Default for Colors {
             rec_bg: [0x00, 0x00, 0xCC, 0xFF],
             border: [0x00, 0xA5, 0xFF, 0xFF],          //amber
             border_dragging: [0xFF, 0x00, 0xFF, 0xFF], //magenta
+            separator: None,
+            separator_subgrid: None,
+            separator_bisect: None,
             crosshair: [0x00, 0xA5, 0xFF, 0xFF],       //amber
             hint_chip_bg: [0x2E, 0x1E, 0x1E, 0xEE],
             hint_text: [0x00, 0xCC, 0xFF, 0xFF],

--- a/src/render.rs
+++ b/src/render.rs
@@ -137,6 +137,15 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
             let lx = x + cell_w.saturating_sub(label_w) / 2;
             let ly = y + cell_h.saturating_sub(char_h) / 2;
             c.draw_glyph(lx, ly, first_hint, c1, scale);
+            let border = if dragging {
+                colors.border_dragging
+            } else {
+                colors.border
+            };
+            c.fill_rect(x, y, cell_w, 1, border);
+            c.fill_rect(x, y + cell_h - 1, cell_w, 1, border);
+            c.fill_rect(x, y, 1, cell_h, border);
+            c.fill_rect(x + cell_w - 1, y, 1, cell_h, border);
             c.draw_glyph(lx + char_w + gap, ly, second_hint, c2, scale);
         }
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -137,16 +137,19 @@ pub fn render_grid(buf: &mut [u8], w: u32, h: u32, input: &InputState, dragging:
             let lx = x + cell_w.saturating_sub(label_w) / 2;
             let ly = y + cell_h.saturating_sub(char_h) / 2;
             c.draw_glyph(lx, ly, first_hint, c1, scale);
-            let border = if dragging {
-                colors.border_dragging
-            } else {
-                colors.border
-            };
-            c.fill_rect(x, y, cell_w, 1, border);
-            c.fill_rect(x, y + cell_h - 1, cell_w, 1, border);
-            c.fill_rect(x, y, 1, cell_h, border);
-            c.fill_rect(x + cell_w - 1, y, 1, cell_h, border);
             c.draw_glyph(lx + char_w + gap, ly, second_hint, c2, scale);
+        }
+    }
+
+    // Inner grid lines only (1..ncols / 1..nrows skips the outer edge).
+    // Transparent by default, so the look is unchanged unless set.
+    let separator = colors.separator.unwrap_or([0, 0, 0, 0]);
+    if separator[3] != 0 {
+        for col in 1..ncols {
+            c.fill_rect(col * cell_w, 0, 1, nrows * cell_h, separator);
+        }
+        for row in 1..nrows {
+            c.fill_rect(0, row * cell_h, ncols * cell_w, 1, separator);
         }
     }
 }
@@ -206,6 +209,20 @@ pub fn render_bisect(buf: &mut [u8], w: u32, h: u32, region: (u32, u32, u32, u32
             );
             let (gs, ox, oy) = glyph_layout(hint, sub_w, sub_h, scale);
             c.draw_glyph(x + ox, y + oy, hint, colors.text_first, gs);
+        }
+    }
+
+    // Inner separators between bisect cells (at the sub-span boundaries,
+    // skipping the region edges). Transparent by default.
+    let separator = colors.separator_bisect.unwrap_or([0, 0, 0, 0]);
+    if separator[3] != 0 {
+        for col in 1..cols {
+            let (x, _) = col_spans[col as usize];
+            c.fill_rect(x, ry, 1, rh, separator);
+        }
+        for row in 1..rows {
+            let (y, _) = row_spans[row as usize];
+            c.fill_rect(rx, y, rw, 1, separator);
         }
     }
 
@@ -800,6 +817,20 @@ fn render_sub_grid(
                 bg,
             );
             c.draw_glyph(x + glyph_ox, y + glyph_oy, hint, text, glyph_scale);
+        }
+    }
+
+    // Inner separators between sub-cells (at the sub-span boundaries, skipping
+    // the outer frame drawn above in `border`). Transparent by default.
+    let separator = colors.separator_subgrid.unwrap_or([0, 0, 0, 0]);
+    if separator[3] != 0 {
+        for sub_col in 1..nsub_cols {
+            let (x, _) = col_spans[sub_col as usize];
+            c.fill_rect(x, cell_y, 1, cell_h, separator);
+        }
+        for sub_row in 1..nsub_rows {
+            let (y, _) = row_spans[sub_row as usize];
+            c.fill_rect(cell_x, y, cell_w, 1, separator);
         }
     }
 }


### PR DESCRIPTION
The 'colors.border' setting has no effect on the main (first) grid. It only applies to the sub-grid and bisect overlays.

This draws the border on every main-grid cell for a consistent table look by reusing the existing pattern in "render_sub_grid". I hope this wasn't intentional, otherwise it would be nice to have a different option to configure the border of the "main" grid.